### PR TITLE
easy build and push

### DIFF
--- a/buildHelper.sh
+++ b/buildHelper.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+TAG="${1}"
+REGISTRY="registry.f5demos.com"
+
+bp () {
+    docker build -t ${REGISTRY}/${1}:${TAG} -t ${REGISTRY}/${1}:latest ${2}
+    docker push ${REGISTRY}/${1}
+}
+
+bp "spa" "front-end"
+bp "api" "back-end"
+bp "inv" "inventory"
+bp "recs" "recommendations"


### PR DESCRIPTION
Added simple bash script to automatically build and push to the private registry.

Do a ```docker login registry.f5demos.com``` for our private reg. Then just run:

```shell
./buildHelper.sh 0.4
```
(add whatever tag you want). 
This will build the spa, api, inv, and recs images, push them with your tag as well as 'latest'. We don't need to build the DB at this point.