### PR TITLE
add DNS for inventory service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     environment:
       - MONGO_URL=mongodb
       - INVENTORY_URL=http://inventory:8002
+    dns:
+      - 10.1.1.6
 
   spa:
     build: ./spa


### PR DESCRIPTION
This will specify that the inventory service should use a DNS resolver of 10.1.1.6