### PR TITLE
listen on 8081 and not 80 for spa

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     build: ./spa
     container_name: spa
     ports:
-      - "8081:80"
+      - "8081:8081"
     links:
       - api
 

--- a/spa/Dockerfile
+++ b/spa/Dockerfile
@@ -30,6 +30,6 @@ FROM nginx:stable-alpine as release
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY --from=builder /app/nginx.conf /etc/nginx/nginx.conf
 
-EXPOSE 80
+EXPOSE 8081
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/spa/nginx.conf
+++ b/spa/nginx.conf
@@ -16,7 +16,7 @@ http {
     sendfile            on;
     keepalive_timeout   65;
     server {
-        listen          80;
+        listen          8081;
         server_name     _ default_server;
         index           index.html;
         location / {


### PR DESCRIPTION
- use port 8081 instead of 80.  this makes the deployment consistent across environments